### PR TITLE
Update utils.py

### DIFF
--- a/bio_hansel/utils.py
+++ b/bio_hansel/utils.py
@@ -195,5 +195,9 @@ def init_subtyping_params(args: Optional[Any] = None,
             subtyping_params.max_perc_intermediate_tiles = args.max_intermediate_tiles
         if args.low_cov_warning:
             subtyping_params.min_coverage_warning = args.low_cov_warning
+        if args.min_kmer_freq:
+            subtyping_params.min_kmer_freq = args.min_kmer_freq
+        if args.max_kmer_freq:
+            subtyping_params.max_kmer_freq = args.max_kmer_freq
 
     return subtyping_params


### PR DESCRIPTION
This change is needed to allow users to enforce the minimum kmer frequency and maximum kmer frequency cut-offs.   These switches are not operational without this change.