### PR TITLE
toupper case bug fix in inputs

### DIFF
--- a/bio_hansel/parsers.py
+++ b/bio_hansel/parsers.py
@@ -54,6 +54,7 @@ def _parse_fasta(f, filepath):
         if isinstance(line, bytes):
             line = line.decode()
         line = line.strip()
+
         if line == '':
             continue
         if line[0] == '>':
@@ -71,7 +72,7 @@ def _parse_fasta(f, filepath):
                     line=line_count,
                     chars=', '.join([str(x) for x in non_nucleotide_chars_in_line]))
                 logging.warning(msg)
-            seqs.append(line)
+            seqs.append(line.upper())
         line_count += 1
     yield header, ''.join(seqs)
 
@@ -120,7 +121,7 @@ def _parse_fastq(f):
         if line[0] == '@':
             header = line.replace('@', '')
         elif line[0] == '+':
-            yield header, seq
+            yield header, seq.upper()
             skip = True
         else:
             seq = line


### PR DESCRIPTION
@peterk87  current version of biohansel does not work on fasta/q files with lower case as comparisons to tiles fail. In current patch all input sequences are converter to upper case on the fly without modification of original input files. The parsers.py was modified at lines 124 and 76. Please accept this change and update bioconda package to a newer version. Thank you.