### PR TITLE
fixing fasta lower case no result bug. added a unit test for subtype_contigs function

### DIFF
--- a/bio_hansel/parsers.py
+++ b/bio_hansel/parsers.py
@@ -71,7 +71,7 @@ def _parse_fasta(f, filepath):
                     line=line_count,
                     chars=', '.join([str(x) for x in non_nucleotide_chars_in_line]))
                 logging.warning(msg)
-            seqs.append(line)
+            seqs.append(line.upper())
         line_count += 1
     yield header, ''.join(seqs)
 
@@ -123,4 +123,4 @@ def _parse_fastq(f):
             yield header, seq
             skip = True
         else:
-            seq = line
+            seq = line.upper()

--- a/tests/test_subtyping_reads.py
+++ b/tests/test_subtyping_reads.py
@@ -4,13 +4,14 @@ from pandas import DataFrame
 from bio_hansel.const import SCHEME_FASTAS
 from bio_hansel.qc.const import QC
 from bio_hansel.subtype import Subtype
-from bio_hansel.subtyper import subtype_reads
+from bio_hansel.subtyper import subtype_reads,subtype_contigs
 from . import check_df_fastq_cols, check_subtype_attrs
 
 genome_name = 'test'
 scheme_heidelberg = 'heidelberg'
 scheme_enteritidis = 'enteritidis'
 
+fasta_heidelberg_pass = 'tests/data/SRR1002850_lowercase.fasta'
 fastq_heidelberg_pass = 'tests/data/SRR5646583_SMALL.fastq'
 fastq_gz_heidelberg_pass = 'tests/data/SRR5646583_SMALL.fastq.gz'
 
@@ -50,6 +51,22 @@ def subtype_enteritidis_fail():
                    n_tiles_matching_subtype_expected='6',
                    qc_status=QC.FAIL)
 
+@pytest.fixture()
+def subtype_heidelberg_SRR1002850_pass():
+    return Subtype(scheme=scheme_heidelberg,
+                   scheme_version=SCHEME_FASTAS[scheme_heidelberg]['version'],
+                   sample=genome_name,
+                   subtype='2.2.2.2.1.4',
+                   file_path=fastq_heidelberg_pass,
+                   are_subtypes_consistent=True,
+                   n_tiles_matching_all=202,
+                   n_tiles_matching_all_expected='202',
+                   n_tiles_matching_positive=17,
+                   n_tiles_matching_positive_expected='17',
+                   n_tiles_matching_subtype=3,
+                   n_tiles_matching_subtype_expected='3',
+                   qc_status=QC.PASS)
+
 
 def test_heidelberg_scheme_vs_qc_passing_reads_with_ac(subtype_heidelberg_pass):
     st, df = subtype_reads(reads=fastq_heidelberg_pass, genome_name=genome_name, scheme=scheme_heidelberg)
@@ -61,3 +78,12 @@ def test_heidelberg_scheme_vs_qc_passing_reads_with_ac(subtype_heidelberg_pass):
     check_subtype_attrs(st, stgz, subtype_heidelberg_pass)
     check_df_fastq_cols(df)
     check_df_fastq_cols(dfgz)
+
+
+
+def test_heidelberg_scheme_and_lowcase_seq_inputs(subtype_heidelberg_SRR1002850_pass):
+    st, df = subtype_contigs(fasta_path=fasta_heidelberg_pass, genome_name=genome_name, scheme=scheme_heidelberg)
+    assert isinstance(st, Subtype)
+    assert isinstance(df, DataFrame)
+    check_subtype_attrs(st,subtype_heidelberg_SRR1002850_pass)
+


### PR DESCRIPTION
@peterk87 current version of biohansel does not work on fasta/q files with lower case as comparisons to ref tiles fail. In current patch all input sequences are converter to upper case on the fly without modification of original input files. Also added unit tests as requested to test fasta contigs functionality as previous tests only focus on fastq inputs.