### PR TITLE
Revert "NA subtype default output"

### DIFF
--- a/bio_hansel/subtype.py
+++ b/bio_hansel/subtype.py
@@ -13,7 +13,7 @@ class Subtype(object):
     file_path = attr.ib()
     scheme = attr.ib(validator=attr.validators.instance_of(str))
     scheme_version = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
-    subtype = attr.ib(default='NA', validator=attr.validators.optional(attr.validators.instance_of(str)))
+    subtype = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     non_present_subtypes = attr.ib(default=None)  # type: Optional[List[str]]
     all_subtypes = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     inconsistent_subtypes = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))


### PR DESCRIPTION
I think it should be kept as `None` or the equivalent Pandas NA/NaN value when transformed to a DataFrame. 

If the issue is with outputting "NA" instead of an empty string in the report output files under the subtype field, then the null/None values can be changed to "NA" in the report DataFrame before being output to a file (https://github.com/phac-nml/biohansel/blob/development/bio_hansel/main.py#L226). See Pandas functions [`fillna`](http://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.fillna.html) and [`isnull`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.isnull.html) (e.g. `df['subtype'][pd.isnull(df['subtype'])] = 'NA' # or whatever Excel's NA value is (#N/A)`. 

Reverts phac-nml/biohansel#78