### PR TITLE
Adds #N/A in subtype field of results when no subtype is found

### DIFF
--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -246,6 +246,7 @@ def main():
         dfsummary = dfsummary.drop(labels='avg_kmer_coverage', axis=1)
 
     dfsummary['subtype'].fillna(value='#N/A', inplace=True)
+    dfsummary['subtype'].replace('','#N/A', inplace=True)
 
     if df_md is not None:
         dfsummary = merge_metadata_with_summary_results(dfsummary, df_md)

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -267,6 +267,7 @@ def main():
         if len(dfs) > 0:
             dfall: pd.DataFrame = pd.concat([df.sort_values('is_pos_kmer', ascending=False) for df in dfs], sort=False)  # type: pd.DataFrame
             dfall['subtype'].fillna(value='#N/A', inplace=True)
+            dfall['subtype'].replace('','#N/A', inplace=True)
             dfall.to_csv(output_kmer_results, **kwargs_for_pd_to_table)
             logging.info('Kmer results written to "{}".'.format(output_kmer_results))
             if args.json:

--- a/bio_hansel/metadata.py
+++ b/bio_hansel/metadata.py
@@ -53,6 +53,4 @@ def merge_metadata_with_summary_results(df_results: pd.DataFrame, df_metadata: p
     Returns:
         Subtyping results with subtype metadata merged in if metadata is present for subtype results.
     """
-    df_results.subtype = df_results.subtype.fillna('')
-    df_results.subtype = df_results.subtype.astype(str)
     return pd.merge(df_results, df_metadata, how='left', on='subtype')


### PR DESCRIPTION
This change completes the partial fix from PR #81 , which only handled cases where there were no kmers found.  This addition now also handles cases where only negative kmers are found, and no subtype is found (Issue #112 ). 