### PR TITLE
Faster reverse complement using translation table

### DIFF
--- a/bio_hansel/utils.py
+++ b/bio_hansel/utils.py
@@ -151,7 +151,8 @@ def collect_fasta_from_dir(input_directory: str) -> List[Tuple[str, str]]:
     return input_genomes
 
 
-NT_SUB = {x: y for x, y in zip('acgtrymkswhbvdnxACGTRYMKSWHBVDNX', 'tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX')}
+NT_SUB = str.maketrans('acgtrymkswhbvdnxACGTRYMKSWHBVDNX',
+                       'tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX')
 
 
 def revcomp(s):
@@ -163,7 +164,7 @@ def revcomp(s):
     Returns:
         str: reverse complement of `s` nucleotide sequence
     """
-    return ''.join([NT_SUB[c] for c in s[::-1]])
+    return s.translate(NT_SUB)[::-1]
 
 
 def is_gzipped(p: str) -> bool:


### PR DESCRIPTION
This change should make revcomp much quicker (37X; 231us vs 6us):

```python
# create random nt sequence
arr = np.array(list('A'*1000+'G'*1000+'C'*1000+'T'*1000))
np.random.shuffle(arr)
seq = ''.join(list(arr))
# `seq` is a randomly shuffled 4k nt sequence

# original revcomp function in biohansel
NT_SUB = {x: y for x, y in zip('acgtrymkswhbvdnxACGTRYMKSWHBVDNX', 'tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX')}
def revcomp(s):
    return ''.join([NT_SUB[c] for c in s[::-1]])

# new proposed revcomp function
nt_comp_trans = str.maketrans('acgtrymkswhbvdnxACGTRYMKSWHBVDNX', 'tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX')
def revcomp_trans(s):
    return s.translate(nt_comp_trans)[::-1]

# benchmark:

%%timeit 
revcomp(seq)
# 231 µs ± 33.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%%timeit
revcomp_trans(seq)
# 6.19 µs ± 79.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# new revcomp function produces the same output
revcomp(seq) == revcomp_trans(seq)
# True
```