### PR TITLE
Covid19

### DIFF
--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -258,6 +258,8 @@ def main():
     if output_kmer_results:
         if len(dfs) > 0:
             dfall: pd.DataFrame = pd.concat([df.sort_values('is_pos_kmer', ascending=False) for df in dfs], sort=False)
+            #Error message is redundant accross each of the k-mers
+            dfall.drop(columns=['qc_message'])
             dfall = df_field_fillna(dfall)
             dfall.to_csv(output_kmer_results, **kwargs_for_pd_to_table)
             logging.info('Kmer results written to "{}".'.format(output_kmer_results))

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -12,15 +12,15 @@ from pkg_resources import resource_filename
 import attr
 import pandas as pd
 
-from . import program_desc, __version__, program_name
-from .const import SUBTYPE_SUMMARY_COLS, REGEX_FASTQ, REGEX_FASTA, JSON_EXT_TMPL
-from .subtype import Subtype
-from .subtype_stats import subtype_counts
-from .subtyper import \
+from bio_hansel import program_desc, __version__, program_name
+from bio_hansel.const import SUBTYPE_SUMMARY_COLS, REGEX_FASTQ, REGEX_FASTA, JSON_EXT_TMPL
+from bio_hansel.subtype import Subtype
+from bio_hansel.subtype_stats import subtype_counts
+from bio_hansel.subtyper import \
     subtype_contigs_samples, \
     subtype_reads_samples
-from .metadata import read_metadata_table, merge_results_with_metadata
-from .utils import (genome_name_from_fasta_path, get_scheme_fasta, does_file_exist, collect_fastq_from_dir,
+from bio_hansel.metadata import read_metadata_table, merge_results_with_metadata
+from bio_hansel.utils import (genome_name_from_fasta_path, get_scheme_fasta, does_file_exist, collect_fastq_from_dir,
                     group_fastqs, collect_fasta_from_dir, init_subtyping_params, df_field_fillna)
 
 SCRIPT_NAME = 'hansel'
@@ -259,7 +259,7 @@ def main():
         if len(dfs) > 0:
             dfall: pd.DataFrame = pd.concat([df.sort_values('is_pos_kmer', ascending=False) for df in dfs], sort=False)
             #Error message is redundant accross each of the k-mers
-            dfall.drop(columns=['qc_message'])
+            dfall = dfall.drop(columns=['qc_message'])
             dfall = df_field_fillna(dfall)
             dfall.to_csv(output_kmer_results, **kwargs_for_pd_to_table)
             logging.info('Kmer results written to "{}".'.format(output_kmer_results))

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -81,6 +81,9 @@ def init_parser():
     parser.add_argument('--min-kmer-freq',
                         type=int,
                         help='Min k-mer freq/coverage')
+    parser.add_argument('--min-kmer-frac',
+                        type=float,
+                        help='Proportion of k-mer required for detection (0.0 - 1)')
     parser.add_argument('--max-kmer-freq',
                         type=int,
                         help='Max k-mer freq/coverage')

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -240,10 +240,10 @@ def filter_by_kmer_fraction(df,min_kmer_frac=0.05):
     Returns:
         - pd.DataFrame with k-mers which satisfy the min-fraction
     """
-    position_counts = df['refposition'].value_counts().rename_axis('position').reset_index(name='counts')
+    position_frequencies = df[['refposition','freq']].groupby(['refposition']).sum().reset_index()
     valid_indexes = []
     for index,row in df.iterrows():
-        frac = row['refposition'] / position_counts.loc[position_counts['position'] == row['refposition'], 'counts'].iloc[0]
+        frac = row['freq'] / position_frequencies.loc[position_frequencies['refposition'] == row['refposition'], 'freq'].iloc[0]
         if frac > min_kmer_frac:
             valid_indexes.append(index)
     return df[df.index.isin(valid_indexes)]

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -229,7 +229,9 @@ def parallel_query_reads(reads: List[Tuple[List[str], str]],
     return outputs
 
 def filter_by_kmer_fraction(df,min_kmer_frac=0.05):
-    """Filter out noisy kmers from high coverage datasets
+    """Filter out low frequency kmers from high coverage datasets which are likely the result of sequencing error
+        Positions will be variably covered in a dataset so the total number of kmers for each position are summed
+        and any k-mer which accounts for less than the min_kmer_frac will be removed from the df
 
     Args:
         df: BioHansel k-mer frequence pandas df

--- a/bio_hansel/subtyping_params.py
+++ b/bio_hansel/subtyping_params.py
@@ -10,7 +10,7 @@ class SubtypingParams(object):
     min_kmer_freq = attr.ib(default=8, validator=attr.validators.instance_of((float, int)))
     max_kmer_freq = attr.ib(default=10000, validator=attr.validators.instance_of((float, int)))
     min_coverage_warning = attr.ib(default=20, validator=attr.validators.instance_of((float, int)))
-    max_degenerate_kmers = attr.ib(default=100000, validator=attr.validators.instance_of(int))
+    max_degenerate_kmers = attr.ib(default=10000000, validator=attr.validators.instance_of(int))
 
     @max_perc_missing_kmers.validator
     def _validate_max_perc_missing_kmers(self, attribute, value):

--- a/bio_hansel/subtyping_params.py
+++ b/bio_hansel/subtyping_params.py
@@ -8,6 +8,7 @@ class SubtypingParams(object):
     min_ambiguous_kmers = attr.ib(default=3, validator=attr.validators.instance_of(int))
     max_perc_intermediate_kmers = attr.ib(default=0.05, validator=attr.validators.instance_of(float))
     min_kmer_freq = attr.ib(default=8, validator=attr.validators.instance_of((float, int)))
+    min_kmer_frac = attr.ib(default=0.05, validator=attr.validators.instance_of(float))
     max_kmer_freq = attr.ib(default=1000000, validator=attr.validators.instance_of((float, int)))
     min_coverage_warning = attr.ib(default=20, validator=attr.validators.instance_of((float, int)))
     max_degenerate_kmers = attr.ib(default=10000000, validator=attr.validators.instance_of(int))

--- a/bio_hansel/subtyping_params.py
+++ b/bio_hansel/subtyping_params.py
@@ -8,7 +8,7 @@ class SubtypingParams(object):
     min_ambiguous_kmers = attr.ib(default=3, validator=attr.validators.instance_of(int))
     max_perc_intermediate_kmers = attr.ib(default=0.05, validator=attr.validators.instance_of(float))
     min_kmer_freq = attr.ib(default=8, validator=attr.validators.instance_of((float, int)))
-    max_kmer_freq = attr.ib(default=10000, validator=attr.validators.instance_of((float, int)))
+    max_kmer_freq = attr.ib(default=1000000, validator=attr.validators.instance_of((float, int)))
     min_coverage_warning = attr.ib(default=20, validator=attr.validators.instance_of((float, int)))
     max_degenerate_kmers = attr.ib(default=10000000, validator=attr.validators.instance_of(int))
 

--- a/bio_hansel/utils.py
+++ b/bio_hansel/utils.py
@@ -200,6 +200,8 @@ def init_subtyping_params(args: Optional[Any] = None,
             subtyping_params.min_coverage_warning = args.low_cov_warning
         if args.min_kmer_freq:
             subtyping_params.min_kmer_freq = args.min_kmer_freq
+        if args.min_kmer_frac:
+            subtyping_params.min_kmer_frac = args.min_kmer_frac
         if args.max_kmer_freq:
             subtyping_params.max_kmer_freq = args.max_kmer_freq
         if args.max_degenerate_kmers:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,7 @@ exp_fasta_cols = ['kmername', 'contig_id', 'refposition', 'seq', 'subtype', 'mat
                   'is_pos_kmer', 'sample', 'file_path', 'scheme', 'scheme_version', 'qc_status', 'qc_message']
 
 exp_fastq_cols = ['kmername', 'refposition', 'subtype', 'seq', 'freq', 'is_pos_kmer', 'is_kmer_freq_okay',
+                  'kmer_fraction','total_refposition_kmer_frequency','is_kmer_fraction_okay',
                   'sample', 'file_path', 'scheme', 'scheme_version', 'qc_status', 'qc_message']
 
 


### PR DESCRIPTION
This update is to make some minor modifications to BioHansel to be more compatible with amplicon based SARS-COV-2 data by introducing the min-kmer-frac parameter which works in combination with the min-kmer-cov parameter to ignore k-mers present in a sample which are less than the defined percentage set by the program with a default of 0.05.  Additionally, the max-kmer-cov has been increased to not cause conflicts with high covered regions being ignored.  The kmer report has also removed the error message field since this adds a lot of extra repeated data for these reports which adds up for larger sample pools.