### PR TITLE
Add bump2version config for easy version updating

### DIFF
--- a/bio_hansel/__init__.py
+++ b/bio_hansel/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 program_name = 'bio_hansel'
 program_summary = 'Subtype microbial genomes using SNV targeting k-mer subtyping schemes.'
 program_desc = program_summary + '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.5.1
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[bumpversion]
+current_version = 2.5.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:bio_hansel/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = docs
+max-line-length = 120
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+collect_ignore = ['setup.py']
+

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/phac-nml/biohansel',
-    version='2.5.0',
+    version='2.5.1',
     zip_safe=False,
 )


### PR DESCRIPTION
With [bumpversion](https://pypi.org/project/bump2version/) installed (`pip install bump2version`), updating the version of biohansel should be as easy as running `$ bumpversion patch` to increment version by 0.0.1 (e.g. `2.5.0` to `2.5.1`). 